### PR TITLE
default image feature

### DIFF
--- a/src/config/image.php
+++ b/src/config/image.php
@@ -5,12 +5,17 @@ return array(
     'upload_dir'  => 'uploads',
     'assets_upload_path' => 'storage/app/uploads',
     'quality'     => 85,
+    'default'     => [
+        'url'     => 'http://placehold.it/150x150',
+        'width'   => 150,
+        'height'  => 150
+    ],
     'dimensions'  => [
-        ['50','50',true, 85, 'thumbnail'],
-        ['160','120',false, 85, 'xsmall'],
-        ['240','180',false, 85, 'small'],
-        ['300','300',true, 85, 'profile'],
-        ['640','480',false, 85, 'medium'],
-        ['800','600',false, 85, 'large']
+        ['50',  '50',   true,   85, 'thumbnail'],
+        ['160', '120',  false,  85, 'xsmall'],
+        ['240', '180',  false,  85, 'small'],
+        ['300', '300',  true,   85, 'profile'],
+        ['640', '480',  false,  85, 'medium'],
+        ['800', '600',  false,  85, 'large']
     ]
 );

--- a/src/dist/ImageFile.php
+++ b/src/dist/ImageFile.php
@@ -12,5 +12,10 @@ class ImageFile
 
 	public function __construct()
 	{
+        $default = Config::get('image.default');
+
+        $this->url = $default['url'];
+        $this->height = $default['height'];
+        $this->width = $default['width'];
 	}	
 }


### PR DESCRIPTION
This PR makes it possible to display a default image when none is available for a model.

This removes errors often experienced in templates when trying to access an object that does not exist.
It also removes the necessity to create checks of whether something exists or not.

Original functionality is also maintained as default can be set to null for all properties.
I added a default image from http://placehold.it/ to make this functionality easy to recognize.

Config file:

```
'default'     => [
        'url' => 'http://placehold.it/150x150',
        'width' => 150,
        'height' => 150
    ]
```
