### PR TITLE
fix #17: trailing querystring on remote images

### DIFF
--- a/src/dist/ImageService.php
+++ b/src/dist/ImageService.php
@@ -81,7 +81,7 @@ class ImageService
 	{
 	    $fileObject = new \SplFileInfo($value);		
 
-		$destination = ImageService::getANewFileName($fileObject->getExtension());
+		$destination = ImageService::getANewFileName(preg_replace('/\?.*/', '', $fileObject->getExtension()));
 		$destinationDirectory = ImageService::getUploadStoragePath().'/'.dirname($destination);
 		if(!\File::isDirectory($destinationDirectory))
 		    \File::makeDirectory($destinationDirectory, 0777, true);


### PR DESCRIPTION
I've just forked and applied @kmaxat suggestion. It might work but maybe adding some test would be fine.