### PR TITLE
supports auto rotation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.5.9",
         "laravel/framework": "^5.1",
-        "imagine/imagine": "v0.5.0"
+        "imagine/imagine": ">=0.6.3"
     },
     "license": "Sahu Soft India Private Limited",
 

--- a/src/dist/ImageService.php
+++ b/src/dist/ImageService.php
@@ -248,9 +248,11 @@ class ImageService
 
 	    try {
 
-	        $imagine->open($source)
-	                ->crop($point,$box)
-	                ->save($destination, array('quality' => $quality)); 
+	        $image = $imagine->open($source);
+		$filterAutorotate = new \Imagine\Filter\Basic\Autorotate();
+		$filterAutorotate->apply($image);
+	        $image->crop($point,$box)
+	              ->save($destination, array('quality' => $quality)); 
 
 	    } catch (\Exception $e) {
 
@@ -282,9 +284,11 @@ class ImageService
 
 	    try {
 
-	        $imagine->open($source)
-	            ->thumbnail($size, $mode)
-	            ->save($destination, array('quality' => $quality));
+	        $image = $imagine->open($source);
+		$filterAutorotate = new \Imagine\Filter\Basic\Autorotate();
+		$filterAutorotate->apply($image);
+	        $image->thumbnail($size, $mode)
+	              ->save($destination, array('quality' => $quality));
 	
 	    } catch (\Exception $e) {
 


### PR DESCRIPTION
When uploading a portrait type photo on iPhone, if you resize or crop in order not to correctly process Exif, the picture will rotate and it will not be in the right direction. Fixed to point in the right direction using Imagine's Autorotate filter.